### PR TITLE
Correctly pass namespace and context to state-manager

### DIFF
--- a/flink-state-manager.sh
+++ b/flink-state-manager.sh
@@ -20,7 +20,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 OUTPUT=$(mktemp)
-npx @cobliteam/flink-state-manager@1.1.1 --values-path "$CHART_PATH"/values.yaml --prod-values-path "${VALUES_FILES[0]}" --context "$HELM_KUBECONTEXT" --menu | tee "$OUTPUT"
+npx @cobliteam/flink-state-manager@1.2.1 --values-path "$CHART_PATH"/values.yaml --prod-values-path "${VALUES_FILES[0]}" --context "$HELM_KUBECONTEXT" --menu | tee "$OUTPUT"
 
 # Create a temporary values file
 TMP_VALUES=$(mktemp)

--- a/flink-state-manager.sh
+++ b/flink-state-manager.sh
@@ -22,8 +22,6 @@ done
 OUTPUT=$(mktemp)
 npx @cobliteam/flink-state-manager@1.1.1 --values-path "$CHART_PATH"/values.yaml --prod-values-path "${VALUES_FILES[0]}" --context "$HELM_KUBECONTEXT" --menu | tee "$OUTPUT"
 
-cat "$OUTPUT"
-
 # Create a temporary values file
 TMP_VALUES=$(mktemp)
 echo "

--- a/flink-state-manager.sh
+++ b/flink-state-manager.sh
@@ -5,17 +5,12 @@ set -o pipefail
 original_args=("$@")
 
 VALUES_FILES=()
-CONTEXT="cobli-prod-devices"
 CHART_PATH=$2
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --values|-f)
       VALUES_FILES+=("$2")
-      shift 2
-      ;;
-    --kube-context)
-      CONTEXT="$2"
       shift 2
       ;;
     *)
@@ -25,7 +20,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 OUTPUT=$(mktemp)
-npx @cobliteam/flink-state-manager@1.1.1 --values-path "$CHART_PATH"/values.yaml --prod-values-path "${VALUES_FILES[0]}" --context "$CONTEXT" --menu | tee "$OUTPUT"
+npx @cobliteam/flink-state-manager@1.1.1 --values-path "$CHART_PATH"/values.yaml --prod-values-path "${VALUES_FILES[0]}" --context "$HELM_KUBECONTEXT" --menu | tee "$OUTPUT"
 
 cat "$OUTPUT"
 
@@ -40,4 +35,5 @@ alex-job-chart:
 " > "$TMP_VALUES"
 
 # Add your values file to the command
-helm upgrade --install "${original_args[@]}" --values "$TMP_VALUES"
+echo "Executing ->  helm upgrade --install "${original_args[@]}" --namespace $HELM_NAMESPACE --kube-context $HELM_KUBECONTEXT --values "$TMP_VALUES""
+helm upgrade --install "${original_args[@]}" --namespace $HELM_NAMESPACE --kube-context $HELM_KUBECONTEXT --values "$TMP_VALUES"


### PR DESCRIPTION
Passa `namespace` e `context` de [forma correta](https://helm.sh/docs/topics/plugins/#:~:text=None%20of%20these%20flags%20are%20passed%20on%20to%20the%20plugin.) para o plugin `flink-state-manager`. O Hem interpreta alguns parâmetros e não os passa para o plugin, mas usa env vars pra isso.