### PR TITLE
Bumpa versão do flink-state-manager

### DIFF
--- a/flink-state-manager.sh
+++ b/flink-state-manager.sh
@@ -9,13 +9,13 @@ CHART_PATH=$2
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --values|-f)
-      VALUES_FILES+=("$2")
-      shift 2
-      ;;
-    *)
-      shift
-      ;;
+  --values | -f)
+    VALUES_FILES+=("$2")
+    shift 2
+    ;;
+  *)
+    shift
+    ;;
   esac
 done
 
@@ -24,20 +24,20 @@ done
 PS3="Select restore mode: "
 select RESTORE_MODE in "From a checkpoint" "From a savepoint"; do
   case $RESTORE_MODE in
-    "From a checkpoint"| "From a savepoint")
-      break
-      ;;
-    *)
-      echo "Invalid option. Please select 1 or 2."
-      ;;
+  "From a checkpoint" | "From a savepoint")
+    break
+    ;;
+  *)
+    echo "Invalid option. Please select 1 or 2."
+    ;;
   esac
- done
+done
 
 OUTPUT=$(mktemp)
 if [[ "$RESTORE_MODE" == "From a checkpoint" ]]; then
-  npx @cobliteam/flink-state-manager@1.4.0 --values-path "$CHART_PATH"/values.yaml --prod-values-path "${VALUES_FILES[0]}" --context "$HELM_KUBECONTEXT" --menu --checkpoints | tee "$OUTPUT"
+  npx @cobliteam/flink-state-manager@1.4.1 --values-path "$CHART_PATH"/values.yaml --prod-values-path "${VALUES_FILES[0]}" --context "$HELM_KUBECONTEXT" --menu --checkpoints | tee "$OUTPUT"
 else
-  npx @cobliteam/flink-state-manager@1.4.0 --values-path "$CHART_PATH"/values.yaml --prod-values-path "${VALUES_FILES[0]}" --context "$HELM_KUBECONTEXT" --menu | tee "$OUTPUT"
+  npx @cobliteam/flink-state-manager@1.4.1 --values-path "$CHART_PATH"/values.yaml --prod-values-path "${VALUES_FILES[0]}" --context "$HELM_KUBECONTEXT" --menu | tee "$OUTPUT"
 fi
 
 # Create a temporary values file. This entry can receive either a savepoint or a
@@ -48,8 +48,8 @@ alex-job-chart:
   jobUpgradeMode: savepoint
   jobRestoreFromSavepoint:
     enabled: true
-    savepointPath: $(tail -n 1 "$OUTPUT"| cut -d ':' -f 2)
-" > "$TMP_VALUES"
+    savepointPath: $(tail -n 1 "$OUTPUT" | cut -d ':' -f 2)
+" >"$TMP_VALUES"
 
 # Add your values file to the command
 echo

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: "restore-state"
-version: "0.2.0"
+version: "0.2.1"
 description: "Upgrades (--install) a Flink job from the selected valid state (savepoint or checkpoint)."
 command: "$HELM_PLUGIN_DIR/flink-state-manager.sh"
 hooks:


### PR DESCRIPTION
Esse bump usa a versão que corrige o uso com deploys que tem nome longo.
